### PR TITLE
Fix meson project a bit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('BestAudioSource', 'cpp',
-  default_options : ['buildtype=release', 'b_ndebug=if-release', 'c_std=c++14'],
+  default_options : ['buildtype=release', 'b_ndebug=if-release', 'cpp_std=c++14'],
   meson_version : '>=0.48.0'
 )
 


### PR DESCRIPTION
~I should put more time for the rest, really.~
It's not critical and project builds anyway, but I just noticed that cpp version was ignored and the reason is that I've used wrong option to declare it.