### PR TITLE
fix 'error: ‘numeric_limits’ is not a member of ‘std’'

### DIFF
--- a/src/vapoursynth.cpp
+++ b/src/vapoursynth.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <algorithm>
 #include <memory>
+#include <limits>
 
 struct BestAudioSourceData {
     VSAudioInfo AI = {};


### PR DESCRIPTION
Compiling on FC34, I have see 
```
'error: ‘numeric_limits’ is not a member of ‘std’'
```

Should be fixed like that.   
