### PR TITLE
Fix audio source iteration with -Wsign-compare

### DIFF
--- a/src/audiosource.cpp
+++ b/src/audiosource.cpp
@@ -292,7 +292,7 @@ bool BestAudioSource::GetExactDuration() {
     if (HasExactNumAudioSamples)
         return true;
     int Index = -1;
-    for (int i = 0; i < MaxAudioSources; i++) {
+    for (size_t i = 0; i < MaxAudioSources; i++) {
         if (Decoders[i] && (Index < 0 || Decoders[Index]->GetFrameNumber() < Decoders[i]->GetFrameNumber()))
             Index = i;
     }
@@ -386,14 +386,14 @@ void BestAudioSource::GetAudio(uint8_t * const * const Data, int64_t Start, int6
         return;
 
     int Index = -1;
-    for (int i = 0; i < MaxAudioSources; i++) {
+    for (size_t i = 0; i < MaxAudioSources; i++) {
         if (Decoders[i] && Decoders[i]->GetSamplePosition() <= Start && (Index < 0 || Decoders[Index]->GetSamplePosition() < Decoders[i]->GetSamplePosition()))
             Index = i;
     }
 
     // If an empty slot exists simply spawn a new decoder there
     if (Index < 0) {
-        for (int i = 0; i < MaxAudioSources; i++) {
+        for (size_t i = 0; i < MaxAudioSources; i++) {
             if (!Decoders[i]) {
                 Index = i;
                 Decoders[i] = new LWAudioDecoder(Source.c_str(), Track, FFOptions);
@@ -405,7 +405,7 @@ void BestAudioSource::GetAudio(uint8_t * const * const Data, int64_t Start, int6
     // No far enough back decoder exists and all slots are occupied so evict a random one
     if (Index < 0) {
         Index = 0;
-        for (int i = 0; i < MaxAudioSources; i++) {
+        for (size_t i = 0; i < MaxAudioSources; i++) {
             if (Decoders[i] && DecoderLastUse[i] < DecoderLastUse[Index])
                 Index = i;
         }


### PR DESCRIPTION
When building bestaudiosource with gcc with `-Werror` and `-Wsign-compare` the build fails due to comparing the loop variable (which is of type `int`) with `MaxAudioSources` (which is `size_t`):

    ../src/audiosource.cpp:408:27: warning: comparison of integer expressions of different signedness: 'int' and 'const size_t' {aka 'const long unsigned int'} [-Wsign-compare]
      408 |         for (int i = 0; i < MaxAudioSources; i++) {
          |                         ~~^~~~~~~~~~~~~~~~~

This fixes the error by changing the loop variable type from `int` to `size_t`.